### PR TITLE
libril: Fix rild crash for dial

### DIFF
--- a/include/telephony/ril.h
+++ b/include/telephony/ril.h
@@ -441,6 +441,7 @@ typedef struct {
     char *          name;       /* Remote party name */
     int             namePresentation; /* 0=Allowed, 1=Restricted, 2=Not Specified/Unknown 3=Payphone */
     RIL_UUS_Info *  uusInfo;    /* NULL or Pointer to User-User Signaling Information */
+    void* unknown;   /*needed for vendor ril */ 
 } RIL_Call;
 
 /* Deprecated, use RIL_Data_Call_Response_v6 */


### PR DESCRIPTION
The used prebuild vendor ril expects an extra field in the RIL_DIAL struct. This field needs to be set to an valid address
otherwise rild will crash. Since the meaning of this extra reference is unkown it is initialized with null.